### PR TITLE
Only use gist ID from URL up to any = or & symbols

### DIFF
--- a/main.js
+++ b/main.js
@@ -34,8 +34,9 @@
   }
 
   // 2. get gist id and file name
+  // Strip anything after '=' or '&' from the first segment to extract clean gist ID
   query = query.split('/');
-  var gistId = query[0];
+  var gistId = query[0].split(/[=&]/)[0];
   var fileName = decodeURIComponent(query[1] || '');
 
   // 3. write data to blank


### PR DESCRIPTION
Fixes:
- #6

Tested locally:

http://localhost:8000/?f40971b693024fbe984a68b73cc283d2=&utm_source=substack&utm_medium=email

<img width="1966" height="766" alt="Screenshot showing the page loading correctly" src="https://github.com/user-attachments/assets/f12932c0-12de-44e1-8961-713291b089ca" />
